### PR TITLE
feat: Change color scheme from blue to green in GitHub Pages

### DIFF
--- a/docs/assets/css/docs.css
+++ b/docs/assets/css/docs.css
@@ -130,9 +130,9 @@
 }
 
 .alert-info {
-    background: linear-gradient(135deg, #dbeafe, #bfdbfe);
-    color: #1e40af;
-    border: 1px solid #60a5fa;
+    background: linear-gradient(135deg, #d1fae5, #a7f3d0);
+    color: #065f46;
+    border: 1px solid #6ee7b7;
 }
 
 /* Requirement Cards */
@@ -389,8 +389,8 @@ pre code {
 }
 
 .run-type.manual {
-    background: #dbeafe;
-    color: #1e40af;
+    background: #d1fae5;
+    color: #065f46;
 }
 
 .run-type.auto {

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,7 +1,7 @@
 /* Global Styles */
 :root {
-    --primary-color: #4F46E5;
-    --secondary-color: #7C3AED;
+    --primary-color: #10B981;
+    --secondary-color: #059669;
     --success-color: #10B981;
     --warning-color: #F59E0B;
     --danger-color: #EF4444;

--- a/style.css
+++ b/style.css
@@ -10,7 +10,7 @@ body {
 
 h1 {
     color: #2c3e50;
-    border-bottom: 3px solid #3498db;
+    border-bottom: 3px solid #10B981;
     padding-bottom: 10px;
     font-size: 28px;
     margin-top: 30px;
@@ -19,7 +19,7 @@ h1 {
 
 h2 {
     color: #2c3e50;
-    border-bottom: 2px solid #3498db;
+    border-bottom: 2px solid #10B981;
     padding-bottom: 8px;
     font-size: 22px;
     margin-top: 25px;
@@ -54,7 +54,7 @@ pre {
     padding: 15px;
     border-radius: 6px;
     overflow-x: auto;
-    border-left: 4px solid #3498db;
+    border-left: 4px solid #10B981;
     margin: 15px 0;
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     font-size: 12px;
@@ -68,7 +68,7 @@ pre code {
 }
 
 blockquote {
-    border-left: 4px solid #3498db;
+    border-left: 4px solid #10B981;
     padding-left: 20px;
     margin: 20px 0;
     color: #7f8c8d;
@@ -105,7 +105,7 @@ li {
 }
 
 a {
-    color: #3498db;
+    color: #10B981;
     text-decoration: none;
 }
 


### PR DESCRIPTION
Fixes #5

## Summary
Changed the color scheme of the GitHub Pages site from blue to green as requested.

## Changes
- Updated primary color from blue (#4F46E5) to green (#10B981)
- Updated secondary color from purple (#7C3AED) to dark green (#059669)
- Changed all blue accents (#3498db) to green (#10B981) across all CSS files
- Modified docs/assets/css/style.css, docs/assets/css/docs.css, and root style.css

Generated with [Claude Code](https://claude.ai/code)